### PR TITLE
Implemented fit method for the normal model based on the fit method for lognormal one. Added initial guess of numerical optimization to method's arguments in both models.

### DIFF
--- a/pysabr/models/hagan_2002_lognormal_sabr.py
+++ b/pysabr/models/hagan_2002_lognormal_sabr.py
@@ -23,7 +23,7 @@ class Hagan2002LognormalSABR(BaseLognormalSABR):
         v_sln = lognormal_vol(k+s, f+s, t, alpha, beta, rho, volvol)
         return v_sln
 
-    def fit(self, k, v_sln):
+    def fit(self, k, v_sln, initial_guess = [0.01, 0.00, 0.10]):
         """
         Calibrate SABR parameters alpha, rho and volvol.
 
@@ -38,7 +38,7 @@ class Hagan2002LognormalSABR(BaseLognormalSABR):
                                   x[2]) * 100 for k_ in k]
             return sum((vols - v_sln)**2)
 
-        x0 = np.array([0.01, 0.00, 0.10])
+        x0 = np.array(initial_guess)
         bounds = [(0.0001, None), (-0.9999, 0.9999), (0.0001, None)]
         res = minimize(vol_square_error, x0, method='L-BFGS-B', bounds=bounds)
         alpha, self.rho, self.volvol = res.x

--- a/pysabr/tests/hagan_2002_normal_sabr/normal_sabr_test_fit.py
+++ b/pysabr/tests/hagan_2002_normal_sabr/normal_sabr_test_fit.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Apr 12 15:13:43 2022
+
+@author: hasek
+"""
+
+import numpy as np
+from pysabr import Hagan2002NormalSABR
+import logging
+
+
+def test_normal_calibration_beta_05():
+    k = np.array([0.05, 0.055, 0.06, 0.065, 0.07, 0.075, 0.08, 0.085, 0.09, 0.095, 0.10])
+    v = np.array([116.63, 111.66, 109.96, 113.97, 124.7, 140.04, 157.3, 175.07, 192.78, 210.26, 227.42])
+    [t, f, s, beta] = np.array([0.5, 0.07520, 0.0000, 0.5000])
+    sabr = Hagan2002NormalSABR(f, s, t, beta=beta)
+    sabr_test = sabr.fit(k, v)
+    [alpha, rho, volvol] = sabr_test
+    logging.debug('\nalpha={:.6f}, rho={:.6f}, volvol={:.6f}'
+                  .format(alpha, rho, volvol))
+    sabr_target = np.array([0.050394, 0.64125, 0.875235])
+    error_max = max(abs(sabr_test - sabr_target))
+    assert (error_max < 1e-5)

--- a/pysabr/tests/hagan_2002_normal_sabr/test_normal_fit.py
+++ b/pysabr/tests/hagan_2002_normal_sabr/test_normal_fit.py
@@ -1,11 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Tue Apr 12 15:13:43 2022
-
-@author: hasek
-"""
-
 import numpy as np
 from pysabr import Hagan2002NormalSABR
 import logging


### PR DESCRIPTION
I was using your PySABR package in my own derivatives project and found out there is a lack of calibration implemented for the Normal (Bachelier) model, however it's very easy to add it based on already existing fit method in the lognormal class. I also found it helpful to have an initial guess for calibrating model parameters to be explicitly available.